### PR TITLE
Transitioned Robot Page to Flexbox

### DIFF
--- a/_pages/robots.html
+++ b/_pages/robots.html
@@ -9,7 +9,7 @@ stylesheets:
   		<source class="center" src="photos/autogear.mp4" type="video/mp4">
 	</video>
 </div>
-<div class="content panel-body">
+<div class="content panel-body card-container">
     <div class="panel-body col-md-4 robot-card">
             <div class="robot-picture" >
                 <img src="photos/Robots/Kernbread.jpg">

--- a/assets/styles/robots.scss
+++ b/assets/styles/robots.scss
@@ -1,5 +1,4 @@
 ---
-# Only the main Sass file needs front matter (the dashes are enough)
 ---
 #video-background {
 //making the video centered horizontally
@@ -51,6 +50,11 @@
   font-family: 'Roboto', sans-serif;
   font-size: 1.5em;
   padding-left:30px;
+}
+
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
 }
 
 //The div ("card") for each robot


### PR DESCRIPTION
Just a simple change to `robots.html` and `robots.scss` so that the robots page is rendered using Flexbox. The use of Flexbox stops the 2015 Robot from being rendered on right side of the third row on monitors larger than 13 in.