### PR TITLE
Removed All Borders for Header

### DIFF
--- a/assets/styles/header.scss
+++ b/assets/styles/header.scss
@@ -2,10 +2,10 @@
 ---
 nav {
 	border-radius: 0 !important;
-	z-index: 1000 !important;
-	height: 70px;
-	border-left: none !important;
-	border-right: none !important;
+    z-index: 1000 !important;
+    border: none !important;
+    padding-top: 1px;
+    height: 70px;
 }
 .navbar-nav {
 	margin-right: 0 !important;


### PR DESCRIPTION
For browsers such as Brave, which attempt to integrate a page's header with its tab when active through the use of colour matching, the header's border disrupts the flow from the tab to the page. Also, the header's border is so minimal that it doesn't serve much purpose anyway.

For reference, here's a snapshot from before the PR in Brave (live site as of 7/14/2018):

<img width="240" alt="screen shot 2018-07-14 at 8 15 01 pm" src="https://user-images.githubusercontent.com/24738899/42729340-d9e2b5c4-87a2-11e8-836b-5d4ab1fad53a.png">


And here is one with the changes from the PR:

<img width="240" alt="screen shot 2018-07-14 at 8 13 07 pm" src="https://user-images.githubusercontent.com/24738899/42729345-03e5f368-87a3-11e8-976d-f38092effd10.png">

